### PR TITLE
Fix typo causing virtualenv to fail

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -19,7 +19,7 @@ function setup_env () {
         exit 0
     else
         git submodule update --init --recursive && build_env $1
-        vitualenv . --prompt="[$1] "
+        virtualenv . --prompt="[$1] "
     fi
 }
 


### PR DESCRIPTION
Trivial typo fix that brings build to a screeching halt